### PR TITLE
Add support for all node-irc options

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Write your own configuration file (`config-example.js`) is a good starting point
 
 ```javascript
 var config = {
+    // required
     server: 'irc.freenode.com',
     nick: 'slackbot',
     username: 'slackbot-username',
@@ -26,6 +27,8 @@ var config = {
     },
     // optionals
     silent: false // default
+    // node-irc options
+    floodProtection: true
 }
 ```
 

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -12,20 +12,32 @@ var slack = require('./slacker');
  * - users: Map of ~login: slack usernames
  */
 var Bot = function (config) {
+    var self = this;
     this.config = _.defaults(config, {
         silent: false,
         nick: 'slckbt',
         username: 'slckbt'
     });
+    // default node-irc options
+    // (@see https://github.com/martynsmith/node-irc/blob/0.3.x/lib/irc.js)
+    this.irc = {
+        userName: this.config.username,
+        channels: Object.keys(this.config.channels),
+        floodProtection: true
+    };
+    ['floodProtection', 'port', 'debug', 'showErrors', 'autoRejoin',
+     'autoConnect', 'secure', 'selfSigned', 'certExpired',
+     'floodProtection', 'floodProtectionDelay', 'sasl', 'stripColors',
+     'channelPrefixes', 'messageSplit'].forEach(function (opt) {
+        if (self.config[opt]) {
+            self.irc[opt] = self.config[opt];
+        }
+    });
     this._usermap = {
         users: this.config.users || {},
         nicks: {}
     };
-    this.client = new IRC.Client(this.config.server, this.config.nick, {
-            userName: this.config.username,
-            channels: Object.keys(this.config.channels)
-        }
-    );
+    this.client = new IRC.Client(this.config.server, this.config.nick, this.irc);
     this.slacker = new slack.Slacker({ token: this.config.token });
     this._trackUsers();
     this._handleErrors();

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "slack-irc-plugin",
   "description": "Tracking an IRC channel directly into your slack channels.",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "homepage": "https://github.com/jimmyhillis/slack-irc-plugin",
   "author": {
     "name": "Jimmy Hillis",


### PR DESCRIPTION
Add support for all `node-irc` options which allows flood protection to be turned on. Can set these options within the standard plugin configuration. They are all visible https://github.com/martynsmith/node-irc/blob/0.3.x/lib/irc.js#L32
